### PR TITLE
VBOX_EXT_PACK_URL HTTPS

### DIFF
--- a/extras/apt-example.list
+++ b/extras/apt-example.list
@@ -2,6 +2,6 @@
 # See /etc/apt/sources.list.d/ for examples.
 
 # non-free sources
-#deb tor+http://ftp.us.debian.org/debian/ buster non-free
-#deb tor+http://ftp.us.debian.org/debian/ buster-backports non-free
-#deb tor+http://security.debian.org/ buster/updates non-free
+#deb tor+https://ftp.us.debian.org/debian/ buster non-free
+#deb tor+https://ftp.us.debian.org/debian/ buster-backports non-free
+#deb tor+https://security.debian.org/ buster/updates non-free

--- a/extras/apt-example.list
+++ b/extras/apt-example.list
@@ -2,6 +2,6 @@
 # See /etc/apt/sources.list.d/ for examples.
 
 # non-free sources
-#deb tor+https://ftp.us.debian.org/debian/ buster non-free
-#deb tor+https://ftp.us.debian.org/debian/ buster-backports non-free
-#deb tor+https://security.debian.org/ buster/updates non-free
+#deb tor+http://ftp.us.debian.org/debian/ buster non-free
+#deb tor+http://ftp.us.debian.org/debian/ buster-backports non-free
+#deb tor+http://security.debian.org/ buster/updates non-free

--- a/lib/virtualbox.sh
+++ b/lib/virtualbox.sh
@@ -64,7 +64,7 @@ install_vbox_ext_pack() {
     local VBOX_EXT_PACK_FILE="Oracle_VM_VirtualBox_Extension_Pack-${VBOX_VERSION}.vbox-extpack"
     mkdir -p "${HVM_HOME}/downloads"
     local VBOX_EXT_PACK_FILE_LOCAL="${HVM_HOME}/downloads/${VBOX_EXT_PACK_FILE}"
-    local VBOX_EXT_PACK_URL="http://download.virtualbox.org/virtualbox/${VBOX_VERSION}/${VBOX_EXT_PACK_FILE}"
+    local VBOX_EXT_PACK_URL="https://download.virtualbox.org/virtualbox/${VBOX_VERSION}/${VBOX_EXT_PACK_FILE}"
 
     # Only download if we don't already have the file cached
     if [ ! -f "${VBOX_EXT_PACK_FILE_LOCAL}" ]; then

--- a/tools/tails-linux-headers-pkg-info.sh
+++ b/tools/tails-linux-headers-pkg-info.sh
@@ -58,7 +58,7 @@ MATCHING_RELEASE=""
 for RELEASE in ${TAILS_DEB_STABLE_RELEASE} testing sid experimental oldstable oldoldstable; do
     echo
     echo "Processing '${RELEASE}'"
-    echo "deb [check-valid-until=no] tor+http://snapshot.debian.org/archive/debian/${PKG_FIRST_SEEN}/ ${RELEASE} main" > "${TMP_SRC_LIST}"
+    echo "deb [check-valid-until=no] tor+https://snapshot.debian.org/archive/debian/${PKG_FIRST_SEEN}/ ${RELEASE} main" > "${TMP_SRC_LIST}"
 
     sudo apt-get -y -q -o Acquire::Check-Valid-Until=false --no-list-cleanup \
         -o Dir::Etc::SourceList=${TMP_SRC_LIST} -o Dir::Etc::SourceParts=- \
@@ -81,7 +81,7 @@ if [ -n "${MATCHING_RELEASE}" ]; then
     echo
 
     for RELEASE in ${TAILS_DEB_STABLE_RELEASE} ${MATCHING_RELEASE}; do
-        echo "deb [check-valid-until=no] tor+http://snapshot.debian.org/archive/debian/${PKG_FIRST_SEEN}/ ${RELEASE} main contrib"
+        echo "deb [check-valid-until=no] tor+https://snapshot.debian.org/archive/debian/${PKG_FIRST_SEEN}/ ${RELEASE} main contrib"
     done
 else
     echo "No release found for ${LINUX_HEADERS}"


### PR DESCRIPTION
Security update. Use https:// for downloading the VirtualBox Extension Pack. An attacker from a Tor Exit Node can tamper with the files during transit.